### PR TITLE
Add tqdm progress bar for fragment loading

### DIFF
--- a/Atif/Gsoc-HealingStones/main_pipeline.py
+++ b/Atif/Gsoc-HealingStones/main_pipeline.py
@@ -19,6 +19,7 @@ import argparse
 from pathlib import Path
 import numpy as np
 import time
+from tqdm import tqdm
 
 # Import our custom modules
 from ply_loader import PLYColorExtractor
@@ -70,12 +71,26 @@ class ReconstructionPipeline:
         
         start_time = time.time()
         
-        # Load all fragments
+        # Load all fragments with progress bar
         print(f"Loading fragments from: {input_directory}")
-        self.fragments = self.ply_extractor.process_all_fragments(input_directory)
+        
+        directory = Path(input_directory)
+        ply_files = list(directory.glob("*.ply"))
+        
+        if not ply_files:
+            raise ValueError(f"No PLY files found in {input_directory}")
+        
+        self.fragments = []
+        with tqdm(total=len(ply_files), desc="Loading fragments", unit="file") as pbar:
+            for ply_file in ply_files:
+                pbar.set_postfix_str(ply_file.name)
+                fragment_data = self.ply_extractor.process_fragment(ply_file)
+                if fragment_data:
+                    self.fragments.append(fragment_data)
+                pbar.update(1)
         
         if not self.fragments:
-            raise ValueError(f"No valid PLY files found in {input_directory}")
+            raise ValueError(f"No valid PLY files could be loaded from {input_directory}")
         
         # Print summary
         print(f"\nLoaded {len(self.fragments)} fragments:")

--- a/Atif/Gsoc-HealingStones/requirements.txt
+++ b/Atif/Gsoc-HealingStones/requirements.txt
@@ -9,3 +9,4 @@ pyyaml>=6.0
 tqdm>=4.62.0
 Pillow>=8.0.0
 psutil>=5.8.0
+tqdm>=4.65.0


### PR DESCRIPTION
## Summary

While exploring the reconstruction pipeline, I noticed that fragment loading provides no visual feedback during processing. This PR adds a progress bar to improve user experience and provide real-time status updates during long-running fragment loads.

## Key Changes

* **Progress Visualization**: Added `tqdm` progress bar to the fragment loading loop in `load_and_process_fragments()` method
* **Real-time Feedback**: Users now see:
  - Current file being processed
  - Progress percentage and file count (e.g., `2/10`)
  - Elapsed time and estimated time remaining
  - Processing speed (files/second)
* **Improved Error Messages**: Enhanced error message clarity when no valid PLY files can be loaded

## Verification

* Tested with multiple fragment sets (3, 5, and 10 PLY files)
* Verified progress bar updates correctly in real-time
* Confirmed error handling works for:
  - Empty directories (no PLY files found)
  - Corrupted/invalid PLY files (files exist but can't be loaded)

**Example Output:**
```bash
Loading fragments from: data/input
Loading fragments: 100%|███████████████| 3/3 [01:23<00:00, 27.8s/file]
```

## Dependencies

* Added: `tqdm>=4.65.0` to `requirements.txt`

## Notes

I'm exploring opportunities to improve the pipeline's user experience.This change is intentionally minimal and focused, but the same pattern could be applied to other long-running operations (feature extraction, surface matching, alignment) if this approach looks good.

Happy to contribute more based on feedback! 