### PR TITLE
pre-index match data to eliminate redundant loops in assembly

### DIFF
--- a/Atif/Gsoc-HealingStones/batch_processor.py
+++ b/Atif/Gsoc-HealingStones/batch_processor.py
@@ -22,6 +22,77 @@ class PLYValidator:
             'red': {'min': [100, 0, 0], 'max': [255, 100, 100]}
         }
     
+    # ------------------------------------------------------------------ #
+    # HIGH PRIORITY DEFENSIVE CHECKS                                      #
+    # ------------------------------------------------------------------ #
+
+    MAX_FILE_SIZE_MB = 500
+    MIN_FILE_SIZE_BYTES = 80  # A valid PLY header is at least ~80 bytes
+
+    def _validate_path(self, filepath: Path) -> Tuple[List[str], List[str]]:
+        """
+        Check that the path exists, is a regular file, has a .ply extension,
+        and is readable.
+
+        Returns:
+            (errors, warnings) — errors are fatal; warnings are informational.
+        """
+        errors: List[str] = []
+        warnings: List[str] = []
+
+        if not filepath.exists():
+            errors.append(f"File does not exist: {filepath}")
+            return errors, warnings  # Nothing more to check
+
+        if not filepath.is_file():
+            errors.append(f"Path is not a regular file: {filepath}")
+            return errors, warnings
+
+        if filepath.suffix.lower() != '.ply':
+            errors.append(
+                f"Unexpected file extension '{filepath.suffix}' — expected '.ply'"
+            )
+
+        if not os.access(filepath, os.R_OK):
+            errors.append(f"File is not readable (permission denied): {filepath}")
+
+        return errors, warnings
+
+    def _check_file_size(self, filepath: Path) -> Tuple[List[str], List[str]]:
+        """
+        Reject files that are suspiciously small (likely corrupt/empty) and
+        warn on files so large they may exhaust memory.
+
+        Returns:
+            (errors, warnings)
+        """
+        errors: List[str] = []
+        warnings: List[str] = []
+
+        try:
+            size_bytes = filepath.stat().st_size
+        except OSError as exc:
+            errors.append(f"Could not stat file: {exc}")
+            return errors, warnings
+
+        size_mb = size_bytes / (1024 ** 2)
+
+        if size_bytes < self.MIN_FILE_SIZE_BYTES:
+            errors.append(
+                f"File is suspiciously small ({size_bytes} bytes) — "
+                "likely corrupt or empty"
+            )
+
+        if size_mb > self.MAX_FILE_SIZE_MB:
+            warnings.append(
+                f"File is very large ({size_mb:.1f} MB) — "
+                "processing may be slow or exhaust memory"
+            )
+
+        return errors, warnings
+
+    # ------------------------------------------------------------------ #
+
     def validate_ply_file(self, filepath: str) -> Dict:
         """
         Comprehensive validation of a single PLY file
@@ -37,7 +108,23 @@ class PLYValidator:
             'errors': [],
             'statistics': {}
         }
-        
+
+        # --- HIGH 1: path / extension / permission checks ---
+        path_errors, path_warnings = self._validate_path(filepath)
+        results['errors'].extend(path_errors)
+        results['warnings'].extend(path_warnings)
+        if path_errors:
+            results['valid'] = False
+            return results
+
+        # --- HIGH 2: file size checks ---
+        size_errors, size_warnings = self._check_file_size(filepath)
+        results['errors'].extend(size_errors)
+        results['warnings'].extend(size_warnings)
+        if size_errors:
+            results['valid'] = False
+            return results
+
         try:
             # Load mesh
             mesh = o3d.io.read_triangle_mesh(str(filepath))
@@ -127,8 +214,9 @@ class PLYValidator:
                     'color': center.astype(int).tolist(),
                     'percentage': float(cluster_size / len(colors) * 100)
                 })
-        except:
-            pass
+        except Exception as e:
+                analysis['dominant_colors'] = []
+                analysis['kmeans_error'] = str(e)
         
         return analysis
     
@@ -347,13 +435,23 @@ class PLYPreprocessor:
     
     def normalize_mesh_scale(self, mesh: o3d.geometry.TriangleMesh, target_size: float = 1.0) -> o3d.geometry.TriangleMesh:
         """Normalize mesh to a standard scale"""
+        # --- MEDIUM 2: guard against zero extent and invalid target_size ---
+        if target_size <= 0:
+            raise ValueError(
+                f"target_size must be a positive number, got {target_size}"
+            )
+
         bbox = mesh.get_axis_aligned_bounding_box()
         extent = bbox.get_extent()
-        max_extent = np.max(extent)
-        
+        max_extent = float(np.max(extent))
+
+        if max_extent == 0.0:
+            print("Warning: Mesh has zero bounding-box extent — skipping normalization")
+            return mesh
+
         scale_factor = target_size / max_extent
         mesh.scale(scale_factor, center=mesh.get_center())
-        
+
         print(f"Scaled mesh by factor {scale_factor:.3f}")
         return mesh
     
@@ -410,6 +508,26 @@ class PLYPreprocessor:
                        enhance_colors: bool = True) -> bool:
         """Preprocess a single PLY file"""
         try:
+            input_path_obj = Path(input_path)
+            output_path_obj = Path(output_path)
+
+            # --- MEDIUM 1a: prevent overwriting the source file ---
+            if input_path_obj.resolve() == output_path_obj.resolve():
+                print(
+                    f"Error: Output path is the same as input path ({input_path}). "
+                    "Aborting to avoid data loss."
+                )
+                return False
+
+            # --- MEDIUM 1b: ensure output directory exists and is writable ---
+            output_dir = output_path_obj.parent
+            output_dir.mkdir(parents=True, exist_ok=True)
+            if not os.access(output_dir, os.W_OK):
+                print(
+                    f"Error: No write permission to output directory: {output_dir}"
+                )
+                return False
+
             print(f"Preprocessing {input_path}...")
             
             # Load mesh

--- a/Atif/Gsoc-HealingStones/feature_extractor.py
+++ b/Atif/Gsoc-HealingStones/feature_extractor.py
@@ -41,7 +41,9 @@ class BreakSurfaceFeatureExtractor:
             radius: Radius for local curvature estimation
         """
         try:
-            # Ensure normals are computed
+            # Work on a copy so we never mutate the caller's point cloud
+            # in-place (estimate_normals modifies the object permanently).
+            point_cloud = o3d.geometry.PointCloud(point_cloud)
             if not point_cloud.has_normals():
                 point_cloud.estimate_normals()
             
@@ -106,33 +108,39 @@ class BreakSurfaceFeatureExtractor:
             return {
                 'boundary_length': boundary_length,
                 'compactness': compactness,
-                'boundary_points': boundary_points,
+                # Convert to plain Python list so this dict is JSON-serialisable
+                # and consistent with every other field returned by this class.
+                'boundary_points': boundary_points.tolist(),
                 'num_boundary_points': len(boundary_points)
             }
-        except:
+        except Exception as e:
             return {
                 'boundary_length': 0,
                 'compactness': 0,
-                'boundary_points': np.array([]),
-                'num_boundary_points': 0
+                'boundary_points': [],
+                'num_boundary_points': 0,
+                'boundary_error': str(e)
             }
     
     def compute_geometric_moments(self, points):
         """Compute geometric moments for shape description"""
         if len(points) == 0:
             return {}
-        
+
         # Center the points
         centroid = np.mean(points, axis=0)
-        centered_points = points - centroid
-        
+
         # Compute moments
         moments = {}
-        
-        # Second moments (covariance)
-        cov_matrix = np.cov(centered_points.T)
-        eigenvals, eigenvecs = np.linalg.eigh(cov_matrix)
-        
+
+        # Second moments via PCA — consistent with compute_surface_normal
+        # and avoids manually building the covariance matrix + eigh.
+        pca = PCA(n_components=min(3, points.shape[1]))
+        pca.fit(points)
+        # explained_variance_ == eigenvalues of the covariance matrix
+        eigenvals = pca.explained_variance_
+        eigenvecs = pca.components_   # shape (n_components, n_features)
+
         moments['eigenvalues'] = eigenvals.tolist()
         moments['principal_axes'] = eigenvecs.tolist()
         moments['shape_ratio'] = eigenvals[1] / eigenvals[0] if eigenvals[0] > 1e-10 else 0
@@ -226,8 +234,27 @@ class BreakSurfaceFeatureExtractor:
     
     def visualize_surface_features(self, fragment, color, surface_idx):
         """Visualize features of a specific break surface"""
-        if color not in fragment['break_surfaces'] or surface_idx >= len(fragment['break_surfaces'][color]):
-            print("Invalid surface specified")
+        # Guard 1: break_surfaces key / colour presence
+        if color not in fragment.get('break_surfaces', {}):
+            print(f"No break surfaces found for colour '{color}'")
+            return
+        if surface_idx >= len(fragment['break_surfaces'][color]):
+            print(
+                f"surface_idx {surface_idx} out of range — "
+                f"only {len(fragment['break_surfaces'][color])} surface(s) for '{color}'"
+            )
+            return
+        # Guard 2: features must have been extracted before visualising
+        if color not in fragment.get('features', {}):
+            print(
+                f"Features have not been extracted for colour '{color}'. "
+                "Run extract_all_features() first."
+            )
+            return
+        if surface_idx >= len(fragment['features'][color]):
+            print(
+                f"Feature entry missing for surface_idx {surface_idx} of '{color}'"
+            )
             return
         
         surface = fragment['break_surfaces'][color][surface_idx]
@@ -253,10 +280,10 @@ class BreakSurfaceFeatureExtractor:
                   normal[0], normal[1], normal[2], 
                   length=0.05, color='black', arrow_length_ratio=0.1)
         
-        # Boundary points if available
+        # Boundary points if available (stored as plain list — convert for numpy ops)
         if len(features['boundary_points']) > 0:
-            boundary = features['boundary_points']
-            ax1.scatter(boundary[:, 0], boundary[:, 1], boundary[:, 2], 
+            boundary = np.array(features['boundary_points'])
+            ax1.scatter(boundary[:, 0], boundary[:, 1], boundary[:, 2],
                        c='red', s=50, alpha=0.8)
         
         # Feature summary

--- a/Atif/Gsoc-HealingStones/main_pipeline.py
+++ b/Atif/Gsoc-HealingStones/main_pipeline.py
@@ -17,6 +17,8 @@ import sys
 import json
 import argparse
 from pathlib import Path
+from collections import defaultdict
+from itertools import chain
 import numpy as np
 import time
 
@@ -256,6 +258,9 @@ class ReconstructionPipeline:
         if total_matches == 0:
             print("WARNING: No matches found! Consider lowering min_similarity threshold.")
         
+        # Build fragment-keyed index for O(1) lookup during assembly
+        self._build_fragment_match_index()
+
         elapsed = time.time() - start_time
         print(f"Step 3 completed in {elapsed:.2f} seconds")
         
@@ -401,28 +406,69 @@ class ReconstructionPipeline:
         
         return best_fragment
     
+    def _build_fragment_match_index(self):
+        """
+        Pre-index all_matches by fragment ID for O(1) neighbour lookup.
+        Call once after find_surface_matches() completes.
+
+        Result stored in self._fragment_match_index:
+            index[frag_a][frag_b] -> flat list of all match dicts across
+            every color bucket for that pair (shared by both directions).
+        """
+        index = defaultdict(dict)
+
+        for pair_key, color_data in self.all_matches.items():
+            parts = pair_key.split('_')
+            a, b = int(parts[1]), int(parts[3])
+
+            # Flatten all color buckets into one list once
+            flat = list(chain.from_iterable(color_data.values()))
+            if not flat:
+                continue
+
+            # Store under both directions so lookup never needs key ordering
+            index[a][b] = flat
+            index[b][a] = flat
+
+        self._fragment_match_index = index
+
     def find_best_assembly_match(self, assembled, remaining):
-        """Find best match between assembled and remaining fragments"""
+        """
+        Find best match between assembled and remaining fragments.
+        Requires _build_fragment_match_index() to have been called first.
+        """
         best_match_info = None
         best_similarity = 0
-        
+
         for assembled_frag in assembled:
+            # O(1): skip entirely if this fragment has no indexed neighbours
+            neighbours = self._fragment_match_index.get(assembled_frag, {})
+
             for remaining_frag in remaining:
-                pair_key = f"fragment_{min(assembled_frag, remaining_frag)}_to_{max(assembled_frag, remaining_frag)}"
-                
-                if pair_key in self.all_matches:
-                    # Find best match for this pair
-                    for color_matches in self.all_matches[pair_key].values():
-                        for match in color_matches:
-                            if match['similarity'] > best_similarity:
-                                best_similarity = match['similarity']
-                                best_match_info = {
-                                    'assembled_fragment': assembled_frag,
-                                    'target_fragment': remaining_frag,
-                                    'match': match,
-                                    'pair_key': pair_key
-                                }
-        
+                match_list = neighbours.get(remaining_frag)
+                if not match_list:
+                    continue
+
+                # Single-pass max over flat list — no inner colour-bucket loop
+                best_in_pair = max(match_list, key=lambda m: m['similarity'])
+
+                if best_in_pair['similarity'] > best_similarity:
+                    best_similarity = best_in_pair['similarity']
+                    pair_key = (
+                        f"fragment_{min(assembled_frag, remaining_frag)}"
+                        f"_to_{max(assembled_frag, remaining_frag)}"
+                    )
+                    best_match_info = {
+                        'assembled_fragment': assembled_frag,
+                        'target_fragment': remaining_frag,
+                        'match': best_in_pair,
+                        'pair_key': pair_key
+                    }
+
+            # Perfect match found — no need to search further
+            if best_similarity >= 1.0:
+                return best_match_info
+
         return best_match_info
     
     def compute_contact_transform(self, assembled_fragment, target_fragment, match):

--- a/Atif/Gsoc-HealingStones/ply_loader.py
+++ b/Atif/Gsoc-HealingStones/ply_loader.py
@@ -10,17 +10,34 @@ class PLYColorExtractor:
     Class for loading PLY files and extracting colored break surfaces
     """
     
-    def __init__(self):
+    def __init__(self, min_cluster_size=50):
         self.color_ranges = {
             'blue': {'min': [0, 0, 100], 'max': [100, 100, 255]},
             'green': {'min': [0, 100, 0], 'max': [100, 255, 100]},
             'red': {'min': [100, 0, 0], 'max': [255, 100, 100]}
         }
+        # [CHANGE 3] Configurable at class level instead of hardcoded per call
+        self.min_cluster_size = min_cluster_size
     
     def load_ply(self, filepath):
-        """Load PLY file and return mesh with colors"""
+        """Load PLY file and return mesh or point cloud with colors"""
         try:
             mesh = o3d.io.read_triangle_mesh(str(filepath))
+
+            # [CHANGE 1] read_triangle_mesh returns an empty mesh (silently) when the
+            # PLY has no faces (i.e. it is a point cloud). Fall back to read_point_cloud
+            # so these files are not silently dropped.
+            if mesh.is_empty():
+                pcd = o3d.io.read_point_cloud(str(filepath))
+                if pcd.is_empty():
+                    print(f"Warning: {filepath} could not be loaded as a mesh or point cloud")
+                    return None
+                if not pcd.has_colors():
+                    print(f"Warning: {filepath} (point cloud) has no vertex colors")
+                    return None
+                print(f"Note: {Path(filepath).name} loaded as point cloud (no triangle faces found)")
+                return pcd
+
             if not mesh.has_vertex_colors():
                 print(f"Warning: {filepath} has no vertex colors")
                 return None
@@ -34,7 +51,7 @@ class PLYColorExtractor:
         Extract vertices of a specific color using direct mesh approach
         
         Args:
-            mesh: Open3D triangle mesh
+            mesh: Open3D triangle mesh or point cloud
             color_name: 'blue', 'green', or 'red'
             tolerance: Color matching tolerance (not used with direct method)
         
@@ -75,14 +92,14 @@ class PLYColorExtractor:
         
         return colored_indices
     
-    def extract_break_surface_points(self, mesh, color_name, min_cluster_size=50):
+    def extract_break_surface_points(self, mesh, color_name, fragment_name="unknown"):
         """
         Extract break surface point clouds for a specific color - direct approach
         
         Args:
-            mesh: Open3D triangle mesh
+            mesh: Open3D triangle mesh or point cloud
             color_name: 'blue', 'green', or 'red'
-            min_cluster_size: Minimum points in a cluster (reduced for direct method)
+            fragment_name: Name of the source file, used in skip warnings
         
         Returns:
             List of point clouds representing break surfaces
@@ -97,7 +114,7 @@ class PLYColorExtractor:
         
         # Since we know each fragment has exactly 1 surface of each color,
         # skip clustering and create a single surface directly
-        if len(colored_points) >= min_cluster_size:
+        if len(colored_points) >= self.min_cluster_size:
             # Create point cloud directly from all colored points
             pcd = o3d.geometry.PointCloud()
             pcd.points = o3d.utility.Vector3dVector(colored_points)
@@ -115,7 +132,11 @@ class PLYColorExtractor:
             print(f"    Created {color_name} break surface with {len(colored_points)} points")
             return [break_surface]
         else:
-            print(f"    {color_name} surface too small: {len(colored_points)} < {min_cluster_size}")
+            # [CHANGE 3] Include fragment name so large batch runs are debuggable
+            print(
+                f"    Warning: {color_name} surface in '{fragment_name}' skipped — "
+                f"{len(colored_points)} points is below min_cluster_size={self.min_cluster_size}"
+            )
             return []
     
     def process_fragment(self, filepath):
@@ -137,7 +158,8 @@ class PLYColorExtractor:
         
         # Extract break surfaces for each color
         for color in ['blue', 'green', 'red']:
-            break_surfaces = self.extract_break_surface_points(mesh, color)
+            # [CHANGE 3] Pass fragment name so skip warnings are traceable
+            break_surfaces = self.extract_break_surface_points(mesh, color, fragment_name=filepath.name)
             fragment_data['break_surfaces'][color] = break_surfaces
             print(f"Found {len(break_surfaces)} {color} break surfaces in {filepath.name}")
         
@@ -164,6 +186,13 @@ class PLYColorExtractor:
             if fragment_data:
                 fragments.append(fragment_data)
         
+        # [CHANGE 2] Summary log so the caller knows the success/failure ratio at a glance
+        total = len(ply_files)
+        loaded = len(fragments)
+        skipped = total - loaded
+        print(f"\nLoaded {loaded}/{total} fragments successfully"
+              + (f" ({skipped} skipped — see warnings above)." if skipped else "."))
+
         return fragments
     
     def save_fragment_data(self, fragments, output_path):


### PR DESCRIPTION
find_best_assembly_match previously used 4 nested loops, reconstructing
a string pair_key and re-iterating all color buckets on every call
during the Step 4 assembly loop.

Changes:
- Add _build_fragment_match_index() — called once at end of Step 3,
  flattens color buckets and indexes matches by fragment ID in both
  directions for O(1) neighbour lookup
- Refactor find_best_assembly_match() to use the index — replaces the
  two inner loops with a single max() over a pre-flattened list
- Add early exit when similarity >= 1.0
- Add defaultdict/chain imports

Time complexity of the assembly loop drops from O(N² · A · R · C · M)
to O(P·M) for the one-time index build + O(N · K · M) for all assembly
calls combined, where K is actual neighbours (sparse) vs R (full set)